### PR TITLE
Update Cake.ISO to target DiscUtils v0.16.13

### DIFF
--- a/src/Cake.ISO/Cake.ISO.csproj
+++ b/src/Cake.ISO/Cake.ISO.csproj
@@ -47,9 +47,9 @@
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="2.0.0" PrivateAssets="All" />
 
-    <PackageReference Include="DiscUtils.Core" Version="0.15.1-ci0007" />
-    <PackageReference Include="DiscUtils.Iso9660" Version="0.15.1-ci0007" />
-    <PackageReference Include="DiscUtils.Streams" Version="0.15.1-ci0007" />
+    <PackageReference Include="DiscUtils.Core" Version="0.16.13" />
+    <PackageReference Include="DiscUtils.Iso9660" Version="0.16.13" />
+    <PackageReference Include="DiscUtils.Streams" Version="0.16.13" />
 
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
Closes https://github.com/cake-contrib/Cake.ISO/issues/24
